### PR TITLE
Adjusted so that parent element offset on page will be reflected

### DIFF
--- a/jQuery.mousetip.js
+++ b/jQuery.mousetip.js
@@ -16,9 +16,9 @@ $.fn.mousetip = function(tip, x, y) {
         $(tip, this).hide().removeAttr('style');
     
     }).mousemove(function(e) {
-        
-        var mouseX = e.pageX + (x || 10);
-        var mouseY = e.pageY + (y || 10);
+        var offset = $(this).offset();
+        var mouseX = e.pageX + (x || 10) - offset.left;
+        var mouseY = e.pageY + (y || 10) - offset.top;
     
         $(tip, this).show().css({
             


### PR DESCRIPTION
Hey,

like the super lightweight approach of this plugin. I had a case where the element containing the tooltip is placed somewhere on the page, and the tooltip would not take this offset into account.

See my PR, it might be useful for others as well and make the plugin more usable.