### PR TITLE
Avoid other relative elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,25 +21,25 @@ See the live demo: [code.nath.co/mousetip](http://code.nath.co/mousetip)
 **jQuery**
 ```javascript
 $(function() {
-    
+
     // Default
     $('div').mousetip('.tip');
-        
+
     // Custom Position
     $('div').mousetip('.tip', 20, 30);
-    
+
 });
-``` 
+```
 
 **CSS**
 ```css
 span.tip {
-    
+
     /* Required */
-    position: absolute;
+    position: fixed;
     z-index: 2;
     display: none;
-    
+
     /* Optional */
     font-size: 15px;
     max-width: 150px;
@@ -48,7 +48,7 @@ span.tip {
     border-radius: 3px;
     box-shadow: 0 1px 2px #666;
     background: #FD0;
-} 
+}
 ```
 
 ## Feedback

--- a/jQuery.mousetip.js
+++ b/jQuery.mousetip.js
@@ -2,28 +2,28 @@
 // Source: github.com/nathco/jQuery.mousetip
 // Author: Nathan Rutzky
 // Update: 1.00
-    
+
 $.fn.mousetip = function(tip, x, y) {
-    
+
     var $this = $(this);
-    
+
     $this.hover(function() {
-        
+
         $(tip, this).show();
-    
+
     }, function() {
-    
+
         $(tip, this).hide().removeAttr('style');
-    
+
     }).mousemove(function(e) {
-        
-        var mouseX = e.pageX + (x || 10);
-        var mouseY = e.pageY + (y || 10);
-    
+
+        var mouseX = e.clientX + (x || 10);
+        var mouseY = e.clientY + (y || 10);
+
         $(tip, this).show().css({
-            
+
             top:mouseY, left:mouseX
-            
+
         });
     });
 };


### PR DESCRIPTION
Bootstrap 4 makes all .col-x-x elements relative, so mousetip doesn’t work in these elements.
